### PR TITLE
Bugfix: i3focus changes title on title events

### DIFF
--- a/i3focus/src/i3focus.c
+++ b/i3focus/src/i3focus.c
@@ -24,11 +24,12 @@ static void
 _j4status_i3focus_window_callback(GObject *object, i3ipcWindowEvent *event, gpointer user_data)
 {
     J4statusSection *section = user_data;
-    if ( g_strcmp0(event->change, "focus") != 0 )
-        return;
-    gchar *name;
-    g_object_get(G_OBJECT(event->container), "name", &name, NULL);
-    j4status_section_set_value(section, name);
+    gboolean focused;
+
+    g_object_get(event->container, "focused", &focused, NULL);
+
+    if ( focused )
+        j4status_section_set_value(section, g_strdup(i3ipc_con_get_name(event->container)));
 }
 
 static void _j4status_i3focus_uninit(J4statusPluginContext *context);


### PR DESCRIPTION
The title should be updated on title events, duh.
