### PR TITLE
fsinfo: Update for libj4status-plugin changes

### DIFF
--- a/fsinfo/man/j4status-fsinfo.conf.xml
+++ b/fsinfo/man/j4status-fsinfo.conf.xml
@@ -129,7 +129,7 @@
                     </term>
                     <listitem>
                         <para>What to display.</para>
-                        <para>Defaults to "<literal>${avail} (${p_avail}%)</literal>".</para>
+                        <para>Defaults to "<literal>${avail(b.1)}b (${p_avail(f04.1)}%)</literal>".</para>
                         <para><varname>reference</varname> can be:</para>
                         <variablelist>
                             <varlistentry>


### PR DESCRIPTION
New change in libnkutils, so format strings are a bit more powerful, again.
Floating formatting is done in libnkutils now, and so is prefix computing.

Could you please check that everything is fine? I’m not sure what tricks you used on the prefix thing, so I hope it works as expected.

The biggest new feature is that we can now have `${p_avail:[;0;100;█;▇;▆;▅;▄;▃;▂;▁; ]}` to use a numeric value as an index for a range of characters.
(This PR is only about updating fsinfo, the feature is in j4status already.)